### PR TITLE
Add product board and simple server skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
 # appli
+
+This repository contains a basic server implementation for a moodboard application.
+
+## Running the server
+
+```
+node src/server.js
+```
+
+This will start a simple HTTP server on port 3000. You can test it with `curl`:
+
+- List moodboards: `curl http://localhost:3000/moodboards`
+- Create one: `curl -X POST --data "My board" http://localhost:3000/moodboard`
+- Delete one: `curl -X DELETE http://localhost:3000/moodboard/<id>`
+
+The implementation is in-memory and intended only as a starting point.

--- a/docs/product_board_v1_mvp.md
+++ b/docs/product_board_v1_mvp.md
@@ -1,0 +1,18 @@
+# Product board v1 - MVP
+
+This document summarizes the main features for the first version of the moodboard application.
+
+| ID | Feature | Objective | Priority | Acceptance Criteria | KPI | Owner | Status |
+|----|---------|-----------|----------|---------------------|-----|-------|--------|
+|1|Create & delete moodboard|Allow user to start a new project or clean workspace|P0|- Sidebar shows a ➕ 'Nouveau moodboard' button\n- A blank moodboard opens instantly after creation\n- Deletion requires confirmation modal|Nb moodboards created / active|Front-end|À faire|
+|2|Folder organisation|Keep workspace clear when user has >5 moodboards|P0|- Drag-and-drop moodboard into folder\n- Rename or delete folder|% moodboards inside a folder|Front-end|À faire|
+|3|Image upload / URL|Store visual inspirations|P0|- Accept .jpg, .png, .webp\n- Show upload progress bar\n- Reject files >10 MB|Upload success rate|Front + Storage|À faire|
+|4|Add text block|Capture quick notes|P0|- Inline editable block, Ctrl+Enter to save\n- Max 500 characters|Notes per session|Front-end|À faire|
+|5|Add web link|Preserve web references|P1|- Pasting a URL creates a link card with favicon & page title|% valid links|Front + Scraper|À faire|
+|6|Free placement (drag-and-drop)|Visual composition flexibility|P0|- Cards move with latency <80 ms\n- Position stored in database|Average drag latency|Front + Firestore|À faire|
+|7|Real-time collaboration|Simultaneous work without conflict|P0|- Show active user avatars\n- Changes visible to others <300 ms\n- Handle edit conflicts gracefully|Sessions with ≥2 users|Front + Firestore|En cours|
+|8|Share via permissioned link|Invite clients / colleagues easily|P0|- Generate unique URL: fboard.app/m/{id}?role=viewer\|editor\n- Viewer/editor rights enforced by Firestore rules|Links shared|Back-end + Rules|À faire|
+|9|Basic history (last edited)|Track recent activity|P2|- Display 'Modifié par X • hh:mm' bottom-right|null|Front + Firestore|Backlog|
+|10|One-page onboarding|Lower first-use friction|P2|- Popup tutorial on first login, replayable|Day-1 activation rate|UX|Backlog|
+|11|Presentation mode|Full-screen share in meetings|P3|- Toggle hides editing UI for clean view|Presentation sessions|Front-end|Backlog|
+

--- a/src/server.js
+++ b/src/server.js
@@ -1,0 +1,41 @@
+const http = require('http');
+const { randomUUID } = require('crypto');
+
+let moodboards = [];
+
+function sendJSON(res, status, data) {
+  res.writeHead(status, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify(data));
+}
+
+const server = http.createServer((req, res) => {
+  if (req.method === 'GET' && req.url === '/moodboards') {
+    sendJSON(res, 200, moodboards);
+  } else if (req.method === 'POST' && req.url === '/moodboard') {
+    let body = '';
+    req.on('data', chunk => (body += chunk));
+    req.on('end', () => {
+      const id = randomUUID();
+      const name = body.trim() || 'Untitled';
+      const board = { id, name };
+      moodboards.push(board);
+      sendJSON(res, 201, board);
+    });
+  } else if (req.method === 'DELETE' && req.url.startsWith('/moodboard/')) {
+    const id = req.url.split('/')[2];
+    const idx = moodboards.findIndex(b => b.id === id);
+    if (idx > -1) {
+      moodboards.splice(idx, 1);
+      sendJSON(res, 200, { deleted: id });
+    } else {
+      sendJSON(res, 404, { error: 'Not found' });
+    }
+  } else {
+    sendJSON(res, 404, { error: 'Not found' });
+  }
+});
+
+const PORT = 3000;
+server.listen(PORT, () => {
+  console.log(`Server listening on http://localhost:${PORT}`);
+});


### PR DESCRIPTION
## Summary
- document product features in docs/product_board_v1_mvp.md
- add a minimal Node.js server that manages moodboards in memory
- update README with instructions for running the server

## Testing
- `node src/server.js > server.log 2>&1 &`
- `curl -s http://localhost:3000/moodboards`
- `curl -s -X POST --data "Board A" http://localhost:3000/moodboard`
- `curl -s http://localhost:3000/moodboards`
- `curl -s -X DELETE http://localhost:3000/moodboard/invalid`
- `curl -s http://localhost:3000/moodboards`


------
https://chatgpt.com/codex/tasks/task_e_686bfdbd5be483238bedd28045d0490b